### PR TITLE
feat(api): add `psp-api` project with ping endpoint and Opentelemetry…

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -5,6 +5,7 @@ import { NodeSDK } from "@opentelemetry/sdk-node";
 import { ConsoleSpanExporter } from "@opentelemetry/sdk-trace-node";
 
 const otelSdk = new NodeSDK({
+	serviceName: "api",
 	traceExporter: new ConsoleSpanExporter(),
 });
 
@@ -12,7 +13,10 @@ otelSdk.start();
 
 app.use("*", otel());
 
-const server = serve(app);
+const server = serve({
+	fetch: app.fetch,
+	port: Number(process.env["API_PORT"]) || 3000,
+});
 
 // graceful shutdown
 process.on("SIGINT", () => {

--- a/apps/psp-api/package.json
+++ b/apps/psp-api/package.json
@@ -1,26 +1,26 @@
 {
-  "name": "@ripste/psp-api",
-  "type": "module",
-  "version": "1.0.0",
-  "main": "src/main.ts",
-  "scripts": {
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "start": "node --experimental-strip-types src/main.ts",
-    "dev": "node --watch --experimental-strip-types src/main.ts"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "description": "",
-  "dependencies": {
-    "@hono/node-server": "^1.14.3",
-    "@hono/otel": "^0.2.0",
-    "@opentelemetry/sdk-node": "^0.202.0",
-    "@opentelemetry/sdk-trace-node": "^2.0.1",
-    "hono": "^4.7.11"
-  },
-  "devDependencies": {
-    "@ripste/tsconfig": "workspace:*"
-  }
+	"name": "@ripste/psp-api",
+	"type": "module",
+	"version": "1.0.0",
+	"main": "src/main.ts",
+	"scripts": {
+		"test": "vitest run",
+		"test:watch": "vitest",
+		"start": "node --experimental-strip-types src/main.ts",
+		"dev": "node --watch --experimental-strip-types src/main.ts"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "ISC",
+	"description": "",
+	"dependencies": {
+		"@hono/node-server": "^1.14.3",
+		"@hono/otel": "^0.2.0",
+		"@opentelemetry/sdk-node": "^0.202.0",
+		"@opentelemetry/sdk-trace-node": "^2.0.1",
+		"hono": "^4.7.11"
+	},
+	"devDependencies": {
+		"@ripste/tsconfig": "workspace:*"
+	}
 }

--- a/apps/psp-api/package.json
+++ b/apps/psp-api/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@ripste/psp-api",
+  "type": "module",
+  "version": "1.0.0",
+  "main": "src/main.ts",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "start": "node --experimental-strip-types src/main.ts",
+    "dev": "node --watch --experimental-strip-types src/main.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@hono/node-server": "^1.14.3",
+    "@hono/otel": "^0.2.0",
+    "@opentelemetry/sdk-node": "^0.202.0",
+    "@opentelemetry/sdk-trace-node": "^2.0.1",
+    "hono": "^4.7.11"
+  },
+  "devDependencies": {
+    "@ripste/tsconfig": "workspace:*"
+  }
+}

--- a/apps/psp-api/src/app.test.ts
+++ b/apps/psp-api/src/app.test.ts
@@ -3,14 +3,14 @@ import { describe, it, expect } from "vitest";
 import { app } from "./app.ts";
 
 describe("Ping Endpoint", () => {
-    const client = testClient(app);
+	const client = testClient(app);
 
-    it("should return ping response", async () => {
-        const res = await client["psp-api"].ping.$get();
+	it("should return ping response", async () => {
+		const res = await client["psp-api"].ping.$get();
 
-        expect(res.status).toBe(200);
-        expect(await res.json()).toEqual({
-            message: "pong",
-        });
-    });
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			message: "pong",
+		});
+	});
 });

--- a/apps/psp-api/src/app.test.ts
+++ b/apps/psp-api/src/app.test.ts
@@ -6,8 +6,7 @@ describe("Ping Endpoint", () => {
 	const client = testClient(app);
 
 	it("should return ping response", async () => {
-		const res = await client["psp-api"].ping.$get();
-
+		const res = await client.ping.$get();
 		expect(res.status).toBe(200);
 		expect(await res.json()).toEqual({
 			message: "pong",

--- a/apps/psp-api/src/app.test.ts
+++ b/apps/psp-api/src/app.test.ts
@@ -1,0 +1,16 @@
+import { testClient } from "hono/testing";
+import { describe, it, expect } from "vitest";
+import { app } from "./app.ts";
+
+describe("Ping Endpoint", () => {
+    const client = testClient(app);
+
+    it("should return ping response", async () => {
+        const res = await client["psp-api"].ping.$get();
+
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({
+            message: "pong",
+        });
+    });
+});

--- a/apps/psp-api/src/app.ts
+++ b/apps/psp-api/src/app.ts
@@ -1,4 +1,4 @@
 import { Hono } from "hono";
-import { pingRouter } from "./routers/ping/ping-router.ts";
+import { pingRouter } from "./routers/ping/ping-router";
 
 export const app = new Hono().route("/psp-api/ping", pingRouter);

--- a/apps/psp-api/src/app.ts
+++ b/apps/psp-api/src/app.ts
@@ -1,0 +1,4 @@
+import { Hono } from "hono";
+import { pingRouter } from "./routers/ping/ping-router.ts";
+
+export const app = new Hono().route("/psp-api/ping", pingRouter);

--- a/apps/psp-api/src/app.ts
+++ b/apps/psp-api/src/app.ts
@@ -1,4 +1,4 @@
 import { Hono } from "hono";
-import { pingRouter } from "./routers/ping/ping-router";
+import { pingRouter } from "./routers/ping/ping-router.ts";
 
-export const app = new Hono().route("/psp-api/ping", pingRouter);
+export const app = new Hono().route("/ping", pingRouter);

--- a/apps/psp-api/src/main.ts
+++ b/apps/psp-api/src/main.ts
@@ -5,6 +5,7 @@ import { NodeSDK } from "@opentelemetry/sdk-node";
 import { ConsoleSpanExporter } from "@opentelemetry/sdk-trace-node";
 
 const otelSdk = new NodeSDK({
+	serviceName: "psp-api",
 	traceExporter: new ConsoleSpanExporter(),
 });
 
@@ -12,7 +13,10 @@ otelSdk.start();
 
 app.use("*", otel());
 
-const server = serve(app);
+const server = serve({
+	fetch: app.fetch,
+	port: Number(process.env["PSP_API_PORT"]) || 3001,
+});
 
 process.on("SIGINT", () => {
 	server.close();

--- a/apps/psp-api/src/main.ts
+++ b/apps/psp-api/src/main.ts
@@ -1,0 +1,29 @@
+import { serve } from "@hono/node-server";
+import { app } from "./app.ts";
+import { otel } from "@hono/otel";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { ConsoleSpanExporter } from "@opentelemetry/sdk-trace-node";
+
+const otelSdk = new NodeSDK({
+    traceExporter: new ConsoleSpanExporter(),
+});
+
+otelSdk.start();
+
+app.use("*", otel());
+
+const server = serve(app);
+
+process.on("SIGINT", () => {
+    server.close();
+    process.exit(0);
+});
+process.on("SIGTERM", () => {
+    server.close((err) => {
+        if (err) {
+            console.error(err);
+            process.exit(1);
+        }
+        process.exit(0);
+    });
+});

--- a/apps/psp-api/src/main.ts
+++ b/apps/psp-api/src/main.ts
@@ -5,7 +5,7 @@ import { NodeSDK } from "@opentelemetry/sdk-node";
 import { ConsoleSpanExporter } from "@opentelemetry/sdk-trace-node";
 
 const otelSdk = new NodeSDK({
-    traceExporter: new ConsoleSpanExporter(),
+	traceExporter: new ConsoleSpanExporter(),
 });
 
 otelSdk.start();
@@ -15,15 +15,15 @@ app.use("*", otel());
 const server = serve(app);
 
 process.on("SIGINT", () => {
-    server.close();
-    process.exit(0);
+	server.close();
+	process.exit(0);
 });
 process.on("SIGTERM", () => {
-    server.close((err) => {
-        if (err) {
-            console.error(err);
-            process.exit(1);
-        }
-        process.exit(0);
-    });
+	server.close((err) => {
+		if (err) {
+			console.error(err);
+			process.exit(1);
+		}
+		process.exit(0);
+	});
 });

--- a/apps/psp-api/src/routers/ping/ping-router.ts
+++ b/apps/psp-api/src/routers/ping/ping-router.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
 
 export const pingRouter = new Hono().get("/", (c) => {
-    return c.json({ message: "pong" });
+	return c.json({ message: "pong" });
 });

--- a/apps/psp-api/src/routers/ping/ping-router.ts
+++ b/apps/psp-api/src/routers/ping/ping-router.ts
@@ -1,0 +1,5 @@
+import { Hono } from "hono";
+
+export const pingRouter = new Hono().get("/", (c) => {
+    return c.json({ message: "pong" });
+});

--- a/apps/psp-api/tsconfig.json
+++ b/apps/psp-api/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "@ripste/tsconfig/tsconfig.json"
+	"extends": "@ripste/tsconfig/tsconfig.json"
 }

--- a/apps/psp-api/tsconfig.json
+++ b/apps/psp-api/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@ripste/tsconfig/tsconfig.json"
+}

--- a/apps/psp-api/vitest.config.ts
+++ b/apps/psp-api/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({});

--- a/biome.json
+++ b/biome.json
@@ -19,7 +19,10 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"recommended": true,
+			"complexity": {
+				"useLiteralKeys": "off"
+			}
 		}
 	},
 	"javascript": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,28 @@ importers:
         specifier: workspace:*
         version: link:../../packages/tsconfig
 
+  apps/psp-api:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.14.3
+        version: 1.14.4(hono@4.7.11)
+      '@hono/otel':
+        specifier: ^0.2.0
+        version: 0.2.2(hono@4.7.11)
+      '@opentelemetry/sdk-node':
+        specifier: ^0.202.0
+        version: 0.202.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^2.0.1
+        version: 2.0.1(@opentelemetry/api@1.9.0)
+      hono:
+        specifier: ^4.7.11
+        version: 4.7.11
+    devDependencies:
+      '@ripste/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
+
   packages/tsconfig:
     dependencies:
       '@tsconfig/node-ts':


### PR DESCRIPTION
… integration

Introduces the `psp-api` project with
a `/psp-api/ping` endpoint
implemented using `hono`. Includes
basic Opentelemetry setup for tracing.
Adds tests and configuration for the API.